### PR TITLE
Updating scripts for fetching and cleaning Metadata

### DIFF
--- a/cleanSRAmetadata_COVID.py
+++ b/cleanSRAmetadata_COVID.py
@@ -1,0 +1,32 @@
+import pandas as pd
+
+Metadata = pd.read_csv("COVID_Metadata_detailed.tsv", sep='\t',
+                       low_memory=False)
+# Selecting unique studies to reduce observations for filtering.
+Metadata_unique = Metadata.drop_duplicates(subset='study_accession',
+                                           keep="last")
+
+# Filtering based on Host = Human & homo sapiens
+# AND
+# Filtering only for SARS-CoV-2 in organism_name or sample_title
+hosts = ['human', 'homo sapiens']
+organism = ['coronavirus', 'cov2', 'covid', 'corona', '2019-nCoV',
+            'SARS-CoV-2', 'nCov']
+Filtered_Metadata = Metadata_unique[((Metadata_unique[
+    'host'].str.contains(
+    '|'.join(hosts), case=False, na=False)) &
+                                     (Metadata_unique[
+                                         'organism_name'].str.contains(
+                                         '|'.join(organism), case=False,
+                                         na=False)) |
+                                     (Metadata_unique[
+                                         'sample_title'].str.contains(
+                                         '|'.join(organism), case=False,
+                                         na=False)))]
+# Getting the SRA run IDS back
+Metadata_Cleaned = Metadata[Metadata['study_accession'].isin(
+     Filtered_Metadata.study_accession)]
+
+# Writing the Cleaned DataFrame to csv
+Metadata_Cleaned.to_csv("COVID_Metadata_detailed_cleaned.tsv", sep="\t",
+                        index=False)

--- a/fetchSRAmetadata.py
+++ b/fetchSRAmetadata.py
@@ -1,0 +1,30 @@
+import sys
+import time
+import pandas as pd
+from pysradb.sraweb import SRAweb
+
+# Connecting SRAweb with
+db = SRAweb()
+
+# Reading the most recent file of NCBI search based on organism
+# taxonomy (07 July, 2020)
+SRA = pd.read_csv("COVID_SRA_07July.csv")
+
+# Extracting distinct studies to reduce the search space
+studies = SRA['sra_study'].unique()
+pd_data = []
+for srp in sorted(studies.tolist()):
+    try:
+        # Fetching Metadata using NCBI API with flag detailed=TRUE to
+        # fetch maximum metadata associated
+        df = db.sra_metadata(srp, detailed=True)
+        pd_data.append(df)
+    except:
+        sys.stderr.write("Error with {}\n".format(srp))
+        time.sleep(0.5)
+    time.sleep(0.5)
+# Concatenating list of DataFrames into one with sorting=False
+final_pd = pd.concat(pd_data, sort=False)
+
+# Final DataFrame written to CSV file
+final_pd.to_csv("COVID_Metadata_detailed.tsv", sep="\t", index=False)


### PR DESCRIPTION
1. `fetchSRAmetadata.py` fetches metadata from SRA using `SRAweb` for the SRA accessions obtained from NCBI using organism ID search. 

2. `cleanSRAmetadata_COVID.py` cleans up the data based on host & organism to remove false positives added by the NCBI search.